### PR TITLE
fix: load enhanced context flags from .env file

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -38,6 +38,24 @@ if [ -f "$NOTIFY_DIR/.env" ]; then
         CLAUDE_NOTIFY_BOT_NAME=$(grep -m1 '^CLAUDE_NOTIFY_BOT_NAME=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
     [ -z "${CLAUDE_NOTIFY_CLEANUP_OLD:-}" ] && \
         CLAUDE_NOTIFY_CLEANUP_OLD=$(grep -m1 '^CLAUDE_NOTIFY_CLEANUP_OLD=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+
+    # Load enhanced context flags
+    [ -z "${CLAUDE_NOTIFY_SHOW_SESSION_INFO:-}" ] && \
+        CLAUDE_NOTIFY_SHOW_SESSION_INFO=$(grep -m1 '^CLAUDE_NOTIFY_SHOW_SESSION_INFO=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+    [ -z "${CLAUDE_NOTIFY_SHOW_TOOL_INFO:-}" ] && \
+        CLAUDE_NOTIFY_SHOW_TOOL_INFO=$(grep -m1 '^CLAUDE_NOTIFY_SHOW_TOOL_INFO=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+    [ -z "${CLAUDE_NOTIFY_SHOW_FULL_PATH:-}" ] && \
+        CLAUDE_NOTIFY_SHOW_FULL_PATH=$(grep -m1 '^CLAUDE_NOTIFY_SHOW_FULL_PATH=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+
+    # Load color overrides
+    [ -z "${CLAUDE_NOTIFY_ONLINE_COLOR:-}" ] && \
+        CLAUDE_NOTIFY_ONLINE_COLOR=$(grep -m1 '^CLAUDE_NOTIFY_ONLINE_COLOR=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+    [ -z "${CLAUDE_NOTIFY_OFFLINE_COLOR:-}" ] && \
+        CLAUDE_NOTIFY_OFFLINE_COLOR=$(grep -m1 '^CLAUDE_NOTIFY_OFFLINE_COLOR=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+    [ -z "${CLAUDE_NOTIFY_APPROVAL_COLOR:-}" ] && \
+        CLAUDE_NOTIFY_APPROVAL_COLOR=$(grep -m1 '^CLAUDE_NOTIFY_APPROVAL_COLOR=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+    [ -z "${CLAUDE_NOTIFY_PERMISSION_COLOR:-}" ] && \
+        CLAUDE_NOTIFY_PERMISSION_COLOR=$(grep -m1 '^CLAUDE_NOTIFY_PERMISSION_COLOR=' "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
 fi
 
 # Check enabled state (file-based .disabled takes precedence over env var)


### PR DESCRIPTION
## Problem

The enhanced context flags and color overrides added in recent commits were not being loaded from `.env` file, causing them to always default to `false`/empty even when explicitly configured.

## Changes

Added loading for all missing environment variables from `.env`:
- `CLAUDE_NOTIFY_SHOW_SESSION_INFO`
- `CLAUDE_NOTIFY_SHOW_TOOL_INFO`
- `CLAUDE_NOTIFY_SHOW_FULL_PATH`
- `CLAUDE_NOTIFY_ONLINE_COLOR`
- `CLAUDE_NOTIFY_OFFLINE_COLOR`
- `CLAUDE_NOTIFY_APPROVAL_COLOR`
- `CLAUDE_NOTIFY_PERMISSION_COLOR`

## Impact

Users with these flags enabled in `.env` will now see:
- Session ID and permission mode in notifications
- Tool name and command details for permissions
- Full directory paths instead of just project names

## Testing

```bash
# With flags enabled in ~/.claude-notify/.env:
CLAUDE_NOTIFY_SHOW_SESSION_INFO=true
CLAUDE_NOTIFY_SHOW_TOOL_INFO=true
CLAUDE_NOTIFY_SHOW_FULL_PATH=true

# Next notification should include these extra fields
```