### PR TITLE
fix: remove 5-minute time limit for approval detection

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -245,20 +245,15 @@ if [ "$HOOK_EVENT" = "PostToolUse" ]; then
     # Check if webhook is configured
     [ -z "${CLAUDE_NOTIFY_WEBHOOK:-}" ] && exit 0
 
-    # Check if there's a recent permission message (within 5 minutes = 300 seconds)
+    # Check if there's a permission message to update
+    # No time limit - some tools can take longer than 5 minutes
     PERMISSION_MSG_FILE="$THROTTLE_DIR/msg-${PROJECT_NAME}-permission_prompt"
     PERMISSION_TIME_FILE="$THROTTLE_DIR/last-permission-${PROJECT_NAME}"
 
-    if [ -f "$PERMISSION_MSG_FILE" ] && [ -f "$PERMISSION_TIME_FILE" ]; then
-        LAST_PERMISSION=$(cat "$PERMISSION_TIME_FILE" 2>/dev/null || echo 0)
-        NOW=$(date +%s)
-        AGE=$((NOW - LAST_PERMISSION))
+    if [ -f "$PERMISSION_MSG_FILE" ]; then
+        MESSAGE_ID=$(cat "$PERMISSION_MSG_FILE" 2>/dev/null)
 
-        # Within 5-minute window - this approval relates to that permission
-        if [ "$AGE" -lt 300 ]; then
-            MESSAGE_ID=$(cat "$PERMISSION_MSG_FILE" 2>/dev/null)
-
-            if [ -n "$MESSAGE_ID" ]; then
+        if [ -n "$MESSAGE_ID" ]; then
                 # Extract and validate webhook ID and token for PATCH endpoint
                 if WEBHOOK_ID_TOKEN=$(extract_webhook_id_token "$CLAUDE_NOTIFY_WEBHOOK"); then
                     # Build approval payload (green color)
@@ -317,7 +312,6 @@ if [ "$HOOK_EVENT" = "PostToolUse" ]; then
                 fi
             fi
         fi
-    fi
 
     exit 0
 fi


### PR DESCRIPTION
## Problem

Permission approval notifications weren't updating to green when tools took longer than 5 minutes to execute. The PostToolUse hook would fire but skip the update due to the 300-second time window check.

Example: User approves permission at 9:21 PM, tool runs for 8 minutes, PostToolUse fires at 9:29 PM but skips update because it's outside the 5-minute window.

## Changes

- Removed the 5-minute time check from PostToolUse handler
- Now updates any permission message that has a message ID file
- Message ID file is deleted after successful PATCH, preventing duplicate updates

## Testing

Manually tested PATCH with 9-hour-old permission message - works correctly.

```bash
# Test with old permission message
curl -X PATCH ... /messages/1470650742086959204
# SUCCESS: Message updated
```

## Impact

- Long-running tools (refactoring, tests, builds) will now get approval notifications
- No behavior change for fast tools (<5 minutes)
- More reliable approval tracking overall