### PR TITLE
fix: clean up stale Discord notifications

### DIFF
--- a/tests/test-empty-cwd.sh
+++ b/tests/test-empty-cwd.sh
@@ -18,10 +18,18 @@ source "$HELPER_FILE"
 # Helper to extract PROJECT_NAME from the script, given INPUT
 extract_project_name() {
     local input="$1"
-    # Mimic the exact logic from claude-notify.sh:63-68
+    # Mimic the exact logic from claude-notify.sh (git root with basename fallback)
     local cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null)
     local project_name="unknown"
-    [ -n "$cwd" ] && project_name=$(basename "$cwd")
+    if [ -n "$cwd" ]; then
+        local git_root
+        git_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+        if [ -n "$git_root" ]; then
+            project_name=$(basename "$git_root")
+        else
+            project_name=$(basename "$cwd")
+        fi
+    fi
     project_name=$(echo "$project_name" | tr -cd 'A-Za-z0-9._-')
     # Ensure PROJECT_NAME is never empty after sanitization (fixes Issue #38)
     [ -z "$project_name" ] && project_name="unknown"

--- a/tests/test-idle-cleanup.sh
+++ b/tests/test-idle-cleanup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# test-idle-cleanup.sh -- Tests for PostToolUse idle message cleanup
+#
+# Verifies that:
+#   - Idle message file is removed on PostToolUse
+#   - Permission message file is NOT affected by idle cleanup
+#   - Session message file is NOT affected by idle cleanup
+#   - No error when idle file doesn't exist (no-op)
+#   - Cleanup is one-shot (second call is a no-op)
+
+set -uo pipefail
+
+# Set up test environment if running standalone
+[ -z "${HELPER_FILE:-}" ] && source "$(dirname "$0")/setup.sh"
+
+source "$HELPER_FILE"
+
+PROJECT="test-proj-idle"
+
+# Helper: simulate the PostToolUse idle cleanup logic
+simulate_idle_cleanup() {
+    local project="$1"
+    local idle_file="$THROTTLE_DIR/msg-${project}-idle_prompt"
+    # Mirrors the delete_discord_message logic (minus actual curl)
+    if [ -f "$idle_file" ]; then
+        rm -f "$idle_file" 2>/dev/null || true
+    fi
+}
+
+# -- Tests --
+
+# 1. Idle message file is removed by PostToolUse
+echo "idle-msg-500" > "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+assert_true "Idle file exists before cleanup" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+simulate_idle_cleanup "$PROJECT"
+assert_false "Idle file removed after cleanup" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+
+# 2. Permission message file is NOT affected by idle cleanup
+echo "perm-msg-500" > "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt"
+echo "idle-msg-501" > "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+simulate_idle_cleanup "$PROJECT"
+assert_false "Idle file removed" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+assert_true "Permission file untouched" [ -f "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt" ]
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt"
+
+# 3. Session message file is NOT affected by idle cleanup
+echo "session-msg-500" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+echo "idle-msg-502" > "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+simulate_idle_cleanup "$PROJECT"
+assert_false "Idle file removed" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+assert_true "Session file untouched" [ -f "$THROTTLE_DIR/msg-${PROJECT}-session" ]
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+# 4. No error when idle file doesn't exist (no-op)
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+simulate_idle_cleanup "$PROJECT"  # should be a silent no-op
+assert_false "No idle file, no error" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+
+# 5. Second cleanup call is a no-op (one-shot behavior)
+echo "idle-msg-503" > "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+simulate_idle_cleanup "$PROJECT"
+assert_false "First cleanup removes file" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+simulate_idle_cleanup "$PROJECT"  # second call should be silent no-op
+assert_false "Second cleanup is no-op" [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]
+
+# 6. Idle cleanup is per-project (different projects don't interfere)
+echo "idle-a" > "$THROTTLE_DIR/msg-projA-idle_prompt"
+echo "idle-b" > "$THROTTLE_DIR/msg-projB-idle_prompt"
+simulate_idle_cleanup "projA"
+assert_false "Project A idle cleaned" [ -f "$THROTTLE_DIR/msg-projA-idle_prompt" ]
+assert_true "Project B idle untouched" [ -f "$THROTTLE_DIR/msg-projB-idle_prompt" ]
+rm -f "$THROTTLE_DIR/msg-projB-idle_prompt"
+
+# -- Cleanup and summary --
+
+test_summary
+rc=$?
+[ "${STANDALONE:-0}" = "1" ] && rm -rf "$TEST_TMPDIR"
+exit $rc

--- a/tests/test-project-name.sh
+++ b/tests/test-project-name.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# test-project-name.sh -- Tests for git-based project name resolution
+#
+# Verifies that:
+#   - Git repo root is used when CWD is inside a git repo
+#   - basename fallback works for non-git directories
+#   - Monorepo subdirectories resolve to repo root name
+#   - Empty/missing CWD still resolves to "unknown"
+
+set -uo pipefail
+
+# Set up test environment if running standalone
+[ -z "${HELPER_FILE:-}" ] && source "$(dirname "$0")/setup.sh"
+
+source "$HELPER_FILE"
+
+# Helper to extract PROJECT_NAME, mirroring the script's logic
+extract_project_name() {
+    local input="$1"
+    local cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null)
+    local project_name="unknown"
+    if [ -n "$cwd" ]; then
+        local git_root
+        git_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+        if [ -n "$git_root" ]; then
+            project_name=$(basename "$git_root")
+        else
+            project_name=$(basename "$cwd")
+        fi
+    fi
+    project_name=$(echo "$project_name" | tr -cd 'A-Za-z0-9._-')
+    [ -z "$project_name" ] && project_name="unknown"
+    echo "$project_name"
+}
+
+# -- Tests --
+
+# 1. Git repo root: CWD inside a git repo resolves to repo name
+# Use this project's own directory as a known git repo
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$TESTS_DIR")"
+result=$(extract_project_name "{\"cwd\": \"$TESTS_DIR\"}")
+assert_eq "Git subdir resolves to repo root name" "claude-code-notify" "$result"
+
+# 2. Git repo root: CWD is the repo root itself
+result=$(extract_project_name "{\"cwd\": \"$PROJECT_DIR\"}")
+assert_eq "Git repo root resolves to repo name" "claude-code-notify" "$result"
+
+# 3. Non-git directory falls back to basename
+NONGIT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/my-plain-dir.XXXXXX")
+result=$(extract_project_name "{\"cwd\": \"$NONGIT_DIR\"}")
+expected=$(basename "$NONGIT_DIR")
+# Sanitize expected the same way
+expected=$(echo "$expected" | tr -cd 'A-Za-z0-9._-')
+assert_eq "Non-git dir falls back to basename" "$expected" "$result"
+rm -rf "$NONGIT_DIR"
+
+# 4. Empty CWD still gives "unknown"
+result=$(extract_project_name '{"cwd": ""}')
+assert_eq "Empty CWD → unknown" "unknown" "$result"
+
+# 5. Missing CWD still gives "unknown"
+result=$(extract_project_name '{"hook_event_name": "Notification"}')
+assert_eq "Missing CWD → unknown" "unknown" "$result"
+
+# 6. Monorepo simulation: deep subdirectory resolves to repo root
+# Use this project's tests/  as a nested path
+result=$(extract_project_name "{\"cwd\": \"$TESTS_DIR\"}")
+assert_eq "Monorepo subdir resolves to repo root" "claude-code-notify" "$result"
+
+# -- Cleanup and summary --
+
+test_summary
+rc=$?
+[ "${STANDALONE:-0}" = "1" ] && rm -rf "$TEST_TMPDIR"
+exit $rc

--- a/tests/test-session-lifecycle.sh
+++ b/tests/test-session-lifecycle.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# test-session-lifecycle.sh -- Tests for session message ID tracking and fallback chain
+#
+# Verifies that:
+#   - Session message ID file is created at expected path
+#   - SessionEnd fallback chain: idle → permission → session
+#   - Session message file is always cleaned up on SessionEnd
+#   - Duplicate SessionStart deletes previous session message file
+
+set -uo pipefail
+
+# Set up test environment if running standalone
+[ -z "${HELPER_FILE:-}" ] && source "$(dirname "$0")/setup.sh"
+
+source "$HELPER_FILE"
+
+PROJECT="test-proj-session"
+
+# -- Tests --
+
+# 1. Session message ID file path follows expected pattern
+SESSION_FILE="$THROTTLE_DIR/msg-${PROJECT}-session"
+echo "session-msg-001" > "$SESSION_FILE"
+assert_true "Session msg file created at expected path" [ -f "$SESSION_FILE" ]
+assert_eq "Session msg ID content correct" "session-msg-001" "$(cat "$SESSION_FILE")"
+rm -f "$SESSION_FILE"
+
+# 2. Fallback priority: idle message takes precedence over session
+echo "idle-msg-100" > "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+echo "session-msg-100" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+# Simulate SessionEnd fallback logic
+MESSAGE_ID=""
+MESSAGE_ID_FILE=""
+if [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+fi
+if [ -z "$MESSAGE_ID" ] && [ -f "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-permission_prompt"
+fi
+if [ -z "$MESSAGE_ID" ] && [ -f "$THROTTLE_DIR/msg-${PROJECT}-session" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-session")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-session"
+fi
+assert_eq "Idle takes priority over session" "idle-msg-100" "$MESSAGE_ID"
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+# 3. Fallback priority: permission message takes precedence over session
+echo "perm-msg-200" > "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt"
+echo "session-msg-200" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+MESSAGE_ID=""
+MESSAGE_ID_FILE=""
+if [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+fi
+if [ -z "$MESSAGE_ID" ] && [ -f "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-permission_prompt"
+fi
+if [ -z "$MESSAGE_ID" ] && [ -f "$THROTTLE_DIR/msg-${PROJECT}-session" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-session")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-session"
+fi
+assert_eq "Permission takes priority over session" "perm-msg-200" "$MESSAGE_ID"
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt" "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+# 4. Session fallback used when no idle or permission
+echo "session-msg-300" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+MESSAGE_ID=""
+MESSAGE_ID_FILE=""
+if [ -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+fi
+if [ -z "$MESSAGE_ID" ] && [ -f "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-permission_prompt")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-permission_prompt"
+fi
+if [ -z "$MESSAGE_ID" ] && [ -f "$THROTTLE_DIR/msg-${PROJECT}-session" ]; then
+    MESSAGE_ID=$(cat "$THROTTLE_DIR/msg-${PROJECT}-session")
+    MESSAGE_ID_FILE="$THROTTLE_DIR/msg-${PROJECT}-session"
+fi
+assert_eq "Session fallback provides message ID" "session-msg-300" "$MESSAGE_ID"
+assert_eq "Session fallback sets correct file" "$THROTTLE_DIR/msg-${PROJECT}-session" "$MESSAGE_ID_FILE"
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+# 5. Session file is always cleaned up on SessionEnd (even when idle was PATCHed)
+echo "session-msg-400" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+echo "idle-msg-400" > "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"
+
+# Simulate: idle was used for PATCH, then session file cleaned unconditionally
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-idle_prompt"  # simulate PATCH cleanup
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-session"       # unconditional cleanup
+assert_false "Session file cleaned up after SessionEnd" [ -f "$THROTTLE_DIR/msg-${PROJECT}-session" ]
+
+# 6. Different projects have independent session files
+echo "proj-a-session" > "$THROTTLE_DIR/msg-projA-session"
+echo "proj-b-session" > "$THROTTLE_DIR/msg-projB-session"
+assert_eq "Project A session ID" "proj-a-session" "$(cat "$THROTTLE_DIR/msg-projA-session")"
+assert_eq "Project B session ID" "proj-b-session" "$(cat "$THROTTLE_DIR/msg-projB-session")"
+rm -f "$THROTTLE_DIR/msg-projA-session" "$THROTTLE_DIR/msg-projB-session"
+
+# 7. SessionStart overwrites previous session file (simulated)
+echo "old-session" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+# Simulate: delete old, then write new
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-session"
+echo "new-session" > "$THROTTLE_DIR/msg-${PROJECT}-session"
+assert_eq "New SessionStart replaces old session file" "new-session" "$(cat "$THROTTLE_DIR/msg-${PROJECT}-session")"
+rm -f "$THROTTLE_DIR/msg-${PROJECT}-session"
+
+# -- Cleanup and summary --
+
+test_summary
+rc=$?
+[ "${STANDALONE:-0}" = "1" ] && rm -rf "$TEST_TMPDIR"
+exit $rc


### PR DESCRIPTION
## Summary

- **Git-based project name**: Use `git rev-parse --show-toplevel` instead of `basename` for project names, fixing monorepo paths (e.g. `chroxy/packages/app` → `chroxy`)
- **Session message tracking**: SessionStart now captures message ID and deletes previous session message before posting, preventing pileup
- **SessionEnd session fallback**: Falls back to session message when no idle/permission exists, and DELETEs session message from Discord (not just the file) to prevent stale "Session Online" duplicates
- **PostToolUse idle cleanup**: Deletes stale idle messages when agent resumes work
- **`delete_discord_message` helper**: DRYs up repeated delete-from-Discord pattern

## Test plan

- [x] 114 tests pass (`bash tests/run-tests.sh`)
- [ ] Manual: start session → Session Online → idle → Ready for input → give input → idle vanishes → end session → single Session Offline
- [ ] Verify monorepo project names resolve to repo root