### PR TITLE
fix: webhook validation, JSON checks, env dedup, uninstall simplify

### DIFF
--- a/tests/test-webhook-extraction.sh
+++ b/tests/test-webhook-extraction.sh
@@ -82,6 +82,33 @@ assert_eq "Webhook URL with very long ID and token" "999888777666555444/abcdefgh
 result=$(extract_webhook_id_token "https://discord.com/api/webhooks/1/a")
 assert_eq "Webhook URL with short ID and token" "1/a" "$result"
 
+# -- Webhook URL format validation tests --
+
+# Helper to check if URL triggers a warning
+validate_webhook_url() {
+    local url="$1"
+    if [[ ! "$url" =~ ^https://discord\.com/api/webhooks/[0-9]+/ ]] && \
+       [[ ! "$url" =~ ^https://discordapp\.com/api/webhooks/[0-9]+/ ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# 13. Valid discord.com webhook URL passes validation
+assert_true "Valid discord.com URL passes" validate_webhook_url "https://discord.com/api/webhooks/123456789/abctoken"
+
+# 14. Valid discordapp.com webhook URL passes validation
+assert_true "Valid discordapp.com URL passes" validate_webhook_url "https://discordapp.com/api/webhooks/123456789/abctoken"
+
+# 15. Random URL fails validation
+assert_false "Random URL fails validation" validate_webhook_url "https://example.com/webhook"
+
+# 16. Empty URL fails validation
+assert_false "Empty URL fails validation" validate_webhook_url ""
+
+# 17. HTTP (non-HTTPS) URL fails validation
+assert_false "HTTP URL fails validation" validate_webhook_url "http://discord.com/api/webhooks/123/abc"
+
 # -- Cleanup and summary --
 
 test_summary


### PR DESCRIPTION
## Summary

- **#41** — Validate webhook URL format on load, warn if it doesn't match Discord webhook pattern (supports both discord.com and discordapp.com)
- **#39** — Check JSON validity with `jq empty` before parsing stdin fields; warn on malformed input and clear INPUT to prevent downstream errors
- **#8** — Extract `load_env_var()` helper to replace 9 identical grep/cut patterns for .env loading (24 lines → 9 function calls)
- **#30** — Simplify install.sh uninstall jq filter from 24 repetitive lines to 4 using `with_entries`

Also closes #11 (throttle cleanup pattern was already removed in the single-status-message PR).

Closes #41, closes #39, closes #8, closes #30, closes #11

## Test plan

- [x] All 173 tests pass (11 new: webhook URL validation, load_env_var, JSON validation)
- [ ] Verify warning appears in stderr for non-Discord webhook URLs
- [ ] Verify `./install.sh --uninstall` still correctly removes all hook types