### PR TITLE
fix: file write error checking and bulk delete pagination

### DIFF
--- a/scripts/discord-bulk-delete.sh
+++ b/scripts/discord-bulk-delete.sh
@@ -2,6 +2,9 @@
 # discord-bulk-delete.sh
 # Bulk delete messages in a Discord channel using bot token
 #
+# Paginates through all messages using Discord's `before` parameter,
+# deleting them one by one. Handles channels with any number of messages.
+#
 # Environment variables:
 #   DISCORD_BOT_TOKEN - Bot token from Discord Developer Portal (required)
 #   DISCORD_DELETE_DELAY - Seconds to wait between deletions (default: 0.5)
@@ -34,61 +37,91 @@ echo "========================================"
 echo "Channel ID: $CHANNEL_ID"
 echo ""
 
-# Fetch messages (up to 100 at a time)
-echo "Fetching messages..."
-MESSAGES=$(curl -s -H "Authorization: Bot $BOT_TOKEN" \
-    "https://discord.com/api/v10/channels/$CHANNEL_ID/messages?limit=100")
-
-# Parse message IDs (jq errors indicate API failure, not empty results)
-if ! MESSAGE_IDS=$(echo "$MESSAGES" | jq -r '.[].id' 2>&1); then
-    echo "Error: Failed to parse Discord API response. Check token and channel ID." >&2
-    # Truncate response to avoid flooding stderr with large JSON
-    TRUNCATED_RESPONSE=$(echo "$MESSAGES" | head -c 200)
-    if [ "${#MESSAGES}" -gt 200 ]; then
-        echo "Response: ${TRUNCATED_RESPONSE}... (truncated)" >&2
-    else
-        echo "Response: $MESSAGES" >&2
-    fi
-    exit 1
-fi
-
-if [ -z "$MESSAGE_IDS" ]; then
-    echo "No messages found or error fetching messages."
-    exit 0
-fi
-
-MESSAGE_COUNT=$(echo "$MESSAGE_IDS" | wc -l | tr -d ' ')
-echo "Found $MESSAGE_COUNT messages to delete"
-echo ""
-
-# Delete messages one by one
 deleted=0
 failed=0
+batch=0
+before_param=""
 
-while IFS= read -r msg_id; do
-    [ -z "$msg_id" ] && continue
+while true; do
+    batch=$((batch + 1))
+    url="https://discord.com/api/v10/channels/$CHANNEL_ID/messages?limit=100"
+    [ -n "$before_param" ] && url="${url}&before=${before_param}"
 
-    echo -n "Deleting message $msg_id... "
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-        -X DELETE \
-        -H "Authorization: Bot $BOT_TOKEN" \
-        "https://discord.com/api/v10/channels/$CHANNEL_ID/messages/$msg_id")
+    echo "Fetching batch $batch..."
+    MESSAGES=$(curl -s -H "Authorization: Bot $BOT_TOKEN" "$url")
 
-    if [ "$HTTP_CODE" = "204" ]; then
-        echo "✓"
-        deleted=$((deleted + 1))
-    else
-        echo "✗ (HTTP $HTTP_CODE)"
-        failed=$((failed + 1))
+    # Parse message IDs (jq errors indicate API failure, not empty results)
+    if ! MESSAGE_IDS=$(echo "$MESSAGES" | jq -r '.[].id' 2>&1); then
+        echo "Error: Failed to parse Discord API response. Check token and channel ID." >&2
+        TRUNCATED_RESPONSE=$(echo "$MESSAGES" | head -c 200)
+        if [ "${#MESSAGES}" -gt 200 ]; then
+            echo "Response: ${TRUNCATED_RESPONSE}... (truncated)" >&2
+        else
+            echo "Response: $MESSAGES" >&2
+        fi
+        exit 1
     fi
 
-    # Rate limit: Discord allows ~5 deletes per second, be more conservative
-    sleep "$DELETE_DELAY"
-done <<< "$MESSAGE_IDS"
+    # No more messages — done
+    if [ -z "$MESSAGE_IDS" ]; then
+        [ "$batch" -eq 1 ] && echo "No messages found in channel."
+        break
+    fi
+
+    MESSAGE_COUNT=$(echo "$MESSAGE_IDS" | wc -l | tr -d ' ')
+    echo "Found $MESSAGE_COUNT messages in batch $batch"
+
+    # Discord returns messages newest-first by default.
+    # Track the last (oldest) message ID for `before=` pagination.
+    LAST_ID=""
+
+    while IFS= read -r msg_id; do
+        [ -z "$msg_id" ] && continue
+        LAST_ID="$msg_id"
+
+        echo -n "  Deleting $msg_id... "
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X DELETE \
+            -H "Authorization: Bot $BOT_TOKEN" \
+            "https://discord.com/api/v10/channels/$CHANNEL_ID/messages/$msg_id")
+
+        if [ "$HTTP_CODE" = "204" ]; then
+            echo "done"
+            deleted=$((deleted + 1))
+        elif [ "$HTTP_CODE" = "429" ]; then
+            echo "rate limited, waiting..."
+            sleep 5
+            # Retry once
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X DELETE \
+                -H "Authorization: Bot $BOT_TOKEN" \
+                "https://discord.com/api/v10/channels/$CHANNEL_ID/messages/$msg_id")
+            if [ "$HTTP_CODE" = "204" ]; then
+                echo "  Retry: done"
+                deleted=$((deleted + 1))
+            else
+                echo "  Retry: failed (HTTP $HTTP_CODE)"
+                failed=$((failed + 1))
+            fi
+        else
+            echo "failed (HTTP $HTTP_CODE)"
+            failed=$((failed + 1))
+        fi
+
+        sleep "$DELETE_DELAY"
+    done <<< "$MESSAGE_IDS"
+
+    # If we got fewer than 100 messages, this was the last page
+    [ "$MESSAGE_COUNT" -lt 100 ] && break
+
+    # Set before= to oldest message ID for next page
+    before_param="$LAST_ID"
+done
 
 echo ""
 echo "========================================"
 echo "Results:"
 echo "  Deleted: $deleted messages"
-echo "  Failed: $failed messages"
+echo "  Failed:  $failed messages"
+echo "  Batches: $batch"
 echo "========================================"


### PR DESCRIPTION
## Summary

- Add `safe_write_file()` helper that logs warnings on write failures instead of silently corrupting state (fixes #31)
- Add pagination to `discord-bulk-delete.sh` using Discord's `before` parameter to handle channels with >100 messages (fixes #47)

## Changes

**claude-notify.sh:**
- New `safe_write_file()` helper wraps all file writes with error checking
- Used in `write_status_state()`, `write_status_msg_id()`, `throttle_check()`, and subagent count writes
- On failure: logs warning to stderr, returns 1 (hook continues running)

**scripts/discord-bulk-delete.sh:**
- Pagination loop using `before=` parameter to walk through all messages
- Rate limit (HTTP 429) detection with retry after 5s backoff
- Batch counter in summary output

**tests/test-cleanup.sh:**
- 4 new tests for `safe_write_file`: write, overwrite, failure returns 1, empty content

## Also in this PR (issue triage)

Closed 17 issues:
- #18, #20: Resolved by previous rewrites
- #9, #12, #14, #16, #19, #23, #26, #29, #32, #35, #40, #48: Architecture over-engineering (won't-fix)
- #13, #15, #37: Test organization (won't-fix)

## Test plan

- [x] 177 tests pass (`bash tests/run-tests.sh`)
- [ ] Manual: verify bulk delete works on channel with >100 messages