### PR TITLE
fix: polish items from code review

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -194,7 +194,7 @@ build_extra_fields() {
 safe_write_file() {
     local file="$1"
     local content="$2"
-    if ! echo "$content" > "$file" 2>/dev/null; then
+    if ! printf '%s\n' "$content" > "$file" 2>/dev/null; then
         echo "claude-notify: warning: failed to write to $file" >&2
     fi
     return 0

--- a/tests/test-cleanup.sh
+++ b/tests/test-cleanup.sh
@@ -123,16 +123,8 @@ assert_eq "Missing var stays empty" "" "${CLAUDE_NOTIFY_SHOW_SESSION_INFO:-}"
 
 # -- safe_write_file tests --
 
-# Inline the function from main script for testing.
-# NOTE: Must stay in sync with safe_write_file() in claude-notify.sh.
-safe_write_file() {
-    local file="$1"
-    local content="$2"
-    if ! echo "$content" > "$file" 2>/dev/null; then
-        echo "claude-notify: warning: failed to write to $file" >&2
-    fi
-    return 0
-}
+# Extract function directly from main script to avoid drift
+eval "$(sed -n '/^safe_write_file()/,/^}/p' "$MAIN_SCRIPT")"
 
 # Successful write
 WRITE_TEST_FILE="$THROTTLE_DIR/safe-write-test"


### PR DESCRIPTION
## Summary

Addresses all 3 remaining review follow-up issues — small polish items.

- **#72**: Parse `Retry-After` header on 429 responses in `discord-bulk-delete.sh` instead of hardcoded `sleep 5`. Sanitizes the value (numeric check, defaults to 5s).
- **#73**: Use `printf '%s\n'` instead of `echo` in `safe_write_file()` to avoid issues with content starting with `-e`, `-n`, etc.
- **#74**: Extract `safe_write_file` from main script in tests via `eval "$(sed ...)"` instead of inlining a copy that could drift.

## Test plan

- [x] 178 tests pass (`bash tests/run-tests.sh`)
- [x] `safe_write_file` tests now use the real function from `claude-notify.sh`