### PR TITLE
fix: load_env_var crash and PostToolUse idle_busy race

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ CLAUDE_NOTIFY_SHOW_FULL_PATH=true
 
 **Tool info (permissions only):**
 - Tool name (Bash, Edit, Write, etc.)
-- Command or operation details (truncated to 200 chars for safety)
+- Command or operation details (truncated to 1000 chars for safety)
 
 **Full path:**
 - Complete working directory path instead of basename

--- a/tests/test-cleanup.sh
+++ b/tests/test-cleanup.sh
@@ -103,7 +103,7 @@ load_env_var() {
     eval "[ -z \"\${${var_name}:-}\" ]" || return 0
     local val
     val=$(grep -m1 "^${var_name}=" "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
-    [ -n "$val" ] && eval "${var_name}=\$val"
+    [ -n "$val" ] && eval "${var_name}=\$val" || true
 }
 
 # Loads value from .env when not set


### PR DESCRIPTION
## Summary
- **load_env_var crash**: `[ -n "$val" ] && eval ...` returned non-zero when a variable wasn't in `.env`, crashing the entire hook script under `set -euo pipefail`. Every notification after SessionStart was dead on arrival. Fixed with `|| true`.
- **PostToolUse idle_busy race**: PostToolUse fires for subagent tool use in the parent session, immediately reverting `idle_busy` back to `online`. Now checks subagent count — if subagents > 0, PostToolUse is a no-op for idle/idle_busy states.
- **README fix**: Tool detail truncation docs said 200 chars, actual code uses 1000.

## Test plan
- [x] 180 tests passing (2 new state transition tests for subagent-aware PostToolUse)
- [x] Verified live: idle notifications now fire correctly across multiple projects
- [x] Verified live: idle_busy state persists while subagents are running