### PR TITLE
fix: review polish from PR #77

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -42,7 +42,9 @@ load_env_var() {
     eval "[ -z \"\${${var_name}:-}\" ]" || return 0
     local val
     val=$(grep -m1 "^${var_name}=" "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
-    [ -n "$val" ] && eval "${var_name}=\$val" || true
+    if [ -n "$val" ]; then
+        eval "${var_name}=\$val"
+    fi
 }
 
 # Load config from .env file (env vars take precedence)

--- a/tests/test-cleanup.sh
+++ b/tests/test-cleanup.sh
@@ -98,13 +98,8 @@ CLAUDE_NOTIFY_WEBHOOK=https://discord.com/api/webhooks/123/abc
 CLAUDE_NOTIFY_BOT_NAME=Test Bot
 ENVFILE
 
-load_env_var() {
-    local var_name="$1"
-    eval "[ -z \"\${${var_name}:-}\" ]" || return 0
-    local val
-    val=$(grep -m1 "^${var_name}=" "$NOTIFY_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
-    [ -n "$val" ] && eval "${var_name}=\$val" || true
-}
+# Extract function directly from main script to avoid drift
+eval "$(sed -n '/^load_env_var()/,/^}/p' "$MAIN_SCRIPT")"
 
 # Loads value from .env when not set
 unset CLAUDE_NOTIFY_BOT_NAME 2>/dev/null || true


### PR DESCRIPTION
## Summary
- **load_env_var if-else**: Replace `[ -n "$val" ] && eval ... || true` with explicit `if [ -n "$val" ]; then eval ...; fi` — avoids silently swallowing eval failures
- **Eliminate duplicate**: Extract `load_env_var` from main script in tests via `eval+sed` (same pattern as `safe_write_file`), so changes to the function don't need syncing
- **Test pattern alignment**: State transition tests now mirror the production guard pattern (`[ "$SUBS" -gt 0 ]` → skip)

## Test plan
- [x] 180 tests passing, no regressions