### PR TITLE
feat: add session metrics to Discord embeds

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -322,13 +322,13 @@ build_status_payload() {
     local bot_name="${CLAUDE_NOTIFY_BOT_NAME:-Claude Code}"
     local extra_fields=$(build_extra_fields)
 
-    local footer_text="Claude Code"
+    local footer_text="$bot_name"
     local session_start=$(read_session_start)
     if [ -n "$session_start" ] && [ "$session_start" != "0" ]; then
         local now=$(date +%s)
         local elapsed=$(( now - session_start ))
         if [ "$elapsed" -ge 0 ]; then
-            footer_text="Claude Code · $(format_duration $elapsed)"
+            footer_text="${bot_name} · $(format_duration $elapsed)"
         fi
     fi
 

--- a/tests/test-activity-tracking.sh
+++ b/tests/test-activity-tracking.sh
@@ -67,15 +67,16 @@ build_extra_fields() { echo "[]"; }
 
 # Stub build_status_payload (offline case only, for summary tests)
 build_offline_payload() {
+    local bot_name="${CLAUDE_NOTIFY_BOT_NAME:-Claude Code}"
     local extra_fields=$(build_extra_fields)
 
-    local footer_text="Claude Code"
+    local footer_text="$bot_name"
     local session_start=$(read_session_start)
     if [ -n "$session_start" ] && [ "$session_start" != "0" ]; then
         local now=$(date +%s)
         local elapsed=$(( now - session_start ))
         if [ "$elapsed" -ge 0 ]; then
-            footer_text="Claude Code · $(format_duration $elapsed)"
+            footer_text="${bot_name} · $(format_duration $elapsed)"
         fi
     fi
 
@@ -113,15 +114,16 @@ build_offline_payload() {
 
 # Stub build_online_payload (for footer tests)
 build_online_payload() {
+    local bot_name="${CLAUDE_NOTIFY_BOT_NAME:-Claude Code}"
     local extra_fields=$(build_extra_fields)
 
-    local footer_text="Claude Code"
+    local footer_text="$bot_name"
     local session_start=$(read_session_start)
     if [ -n "$session_start" ] && [ "$session_start" != "0" ]; then
         local now=$(date +%s)
         local elapsed=$(( now - session_start ))
         if [ "$elapsed" -ge 0 ]; then
-            footer_text="Claude Code · $(format_duration $elapsed)"
+            footer_text="${bot_name} · $(format_duration $elapsed)"
         fi
     fi
 

--- a/tests/test-payload.sh
+++ b/tests/test-payload.sh
@@ -74,13 +74,13 @@ build_status_payload() {
     local bot_name="${CLAUDE_NOTIFY_BOT_NAME:-Claude Code}"
     local extra_fields=$(build_extra_fields)
 
-    local footer_text="Claude Code"
+    local footer_text="$bot_name"
     local session_start=$(read_session_start)
     if [ -n "$session_start" ] && [ "$session_start" != "0" ]; then
         local now=$(date +%s)
         local elapsed=$(( now - session_start ))
         if [ "$elapsed" -ge 0 ]; then
-            footer_text="Claude Code · $(format_duration $elapsed)"
+            footer_text="${bot_name} · $(format_duration $elapsed)"
         fi
     fi
 


### PR DESCRIPTION
## Summary

- **Dynamic footer**: All embeds now show elapsed session time (e.g. "Claude Code · 5m 30s") instead of static "Claude Code"
- **Offline summary**: Session end embed shows "Tools Used" and "Peak Subagents" inline fields when non-zero
- **Zero extra API calls**: Metrics piggyback on existing state updates via lightweight file counters in `/tmp/claude-notify/`

Closes #79

## Implementation

New state files (`session-start-*`, `tool-count-*`, `peak-subagents-*`) follow existing read/write helper pattern. SessionStart initializes counters, PostToolUse increments tool count on every invocation, SubagentStart tracks the high-water mark. All files are cleaned up by `clear_status_files()`.

## Test plan

- [x] 42 new tests in `tests/test-activity-tracking.sh` covering all 7 areas: `format_duration`, state file helpers, tool counter, peak subagent tracking, payload footer, offline summary, cleanup
- [x] Updated `tests/test-payload.sh` local replica to match new footer/offline behavior
- [x] Full suite passes: 222 tests, 0 failures (up from 180)