### PR TITLE
fix: validate throttle_check() cooldown and lock file as numeric

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -559,8 +559,14 @@ patch_status_message() {
 throttle_check() {
     local lock_file="$THROTTLE_DIR/last-${1}"
     local cooldown="$2"
+    # Validate cooldown is numeric; fall back to 30s with a warning
+    if ! [[ "$cooldown" =~ ^[0-9]+$ ]]; then
+        echo "claude-notify: warning: throttle cooldown '$cooldown' is not numeric, using 30s" >&2
+        cooldown=30
+    fi
     if [ -f "$lock_file" ]; then
         local last_sent=$(cat "$lock_file" 2>/dev/null || echo 0)
+        [[ "$last_sent" =~ ^[0-9]+$ ]] || last_sent=0
         local now=$(date +%s)
         [ $(( now - last_sent )) -lt "$cooldown" ] && return 1
     fi


### PR DESCRIPTION
## Summary

- Non-numeric `cooldown` parameter now emits a warning to stderr and falls back to 30s (prevents bash arithmetic errors from `.env` typos like `CLAUDE_NOTIFY_ACTIVITY_THROTTLE=abc`)
- Corrupt lock file timestamps (non-numeric) are treated as 0 instead of crashing
- 3 new tests covering non-numeric cooldown fallback, warning output, and corrupt lock file handling

235 tests pass, 0 failures.

## Test plan

- [x] All 235 tests pass (3 new, 232 existing)
- [ ] Manual: set `CLAUDE_NOTIFY_ACTIVITY_THROTTLE=abc` in `.env`, verify warning and 30s fallback
- [ ] Manual: corrupt a lock file with non-numeric content, verify no crash

Closes #83