### PR TITLE
refactor: extract read_subagent_count helper, add PATCH tests

### DIFF
--- a/lib/notify-helpers.sh
+++ b/lib/notify-helpers.sh
@@ -186,9 +186,9 @@ write_last_tool() {
 read_subagent_count() {
     local scf="${SUBAGENT_COUNT_FILE:-}"
     if [ -n "$scf" ] && [ -f "$scf" ]; then
-        cat "$scf" 2>/dev/null || echo 0
+        cat "$scf" 2>/dev/null || echo "0"
     else
-        echo 0
+        echo "0"
     fi
 }
 

--- a/tests/test-state-transitions.sh
+++ b/tests/test-state-transitions.sh
@@ -188,8 +188,8 @@ assert_eq "SubagentStart rapid PATCH is throttled" "false" "$THROTTLE_PASS_2"
 
 # 13f. No PATCH when webhook is unset (mirrors the guard in claude-notify.sh)
 WEBHOOK_SET="true"
-TEST_WEBHOOK=""
-[ -z "$TEST_WEBHOOK" ] && WEBHOOK_SET="false"
+CLAUDE_NOTIFY_WEBHOOK=""
+[ -z "${CLAUDE_NOTIFY_WEBHOOK:-}" ] && WEBHOOK_SET="false"
 assert_eq "SubagentStart no PATCH without webhook" "false" "$WEBHOOK_SET"
 
 # 13g. read_subagent_count helper returns correct values


### PR DESCRIPTION
## Summary
- Extract duplicated subagent count reading into `read_subagent_count()` helper in `notify-helpers.sh` (closes #88)
- Add 9 integration tests for SubagentStart/Stop PATCH decision logic: state guards, throttle, webhook guard, and helper round-trip (closes #89)

## Test plan
- [x] All 247 tests pass (9 new, 0 regressions)
- [x] `read_subagent_count` helper tested for default and file-read cases
- [x] PATCH fires only on `online` state, not on `idle`/`offline`/empty
- [x] Throttle prevents rapid PATCH updates
- [x] No PATCH when webhook is unset