### PR TITLE
fix: resolve audit issues #111, #114, #121

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,17 @@ When `CLAUDE_NOTIFY_SHOW_ACTIVITY=true`, the online embed also shows **Tools Use
 
 State is stored in `/tmp/claude-notify/` (`status-msg-PROJECT`, `status-state-PROJECT`) and resets on reboot.
 
+## Security considerations
+
+**Tool info may expose secrets** (`CLAUDE_NOTIFY_SHOW_TOOL_INFO`): When enabled, tool commands and file paths are embedded in the Discord message. If Claude runs a command containing secrets (e.g., `curl -H "Authorization: Bearer sk-..."` or `export API_KEY=secret`), that text will be sent to Discord. This feature defaults to `false` — only enable it when you need diagnostic information and understand the risk.
+
+**Webhook URL visible in process listing**: The webhook URL (which contains a secret token) is passed as a command-line argument to `curl`, making it briefly visible via `ps aux` on shared systems. On single-user workstations this is a non-issue. On shared systems, be aware that any user could capture the URL during the brief execution window.
+
+**Mitigation for shared systems:**
+- Restrict read access to the config directory: `chmod 700 ~/.claude-notify` (the installer does this automatically)
+- Keep `CLAUDE_NOTIFY_SHOW_TOOL_INFO=false` (the default)
+- Rotate your Discord webhook URL if you suspect it's been compromised
+
 ## FAQ
 
 **Can I use this with Slack instead of Discord?**

--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -131,6 +131,7 @@ build_extra_fields() {
     fi
 
     # Tool info (for permissions)
+    # WARNING: commands may contain secrets (API keys, tokens). See README security considerations.
     if [ "${CLAUDE_NOTIFY_SHOW_TOOL_INFO:-false}" = "true" ] && [ -n "$TOOL_NAME" ]; then
         extra_fields=$(echo "$extra_fields" | jq -c --arg tool "$TOOL_NAME" '. + [{"name": "Tool", "value": $tool, "inline": true}]')
 

--- a/tests/test-heartbeat.sh
+++ b/tests/test-heartbeat.sh
@@ -41,16 +41,16 @@ assert_true "write_status_state sets last_state_change on transition" [ -n "$LAS
 assert_true "last_state_change is a recent timestamp" [ "$LAST_CHANGE" -gt 1000000000 ]
 
 # 3b. write_status_state does NOT update last_state_change on same-state write
-OLD_CHANGE="$LAST_CHANGE"
-sleep 1
+# Write a known old timestamp, then same-state write should NOT overwrite it
+write_last_state_change "1700000001"
 write_status_state "online"
 NEW_CHANGE=$(read_last_state_change)
-assert_eq "Same-state write does not update timestamp" "$OLD_CHANGE" "$NEW_CHANGE"
+assert_eq "Same-state write does not update timestamp" "1700000001" "$NEW_CHANGE"
 
 # 3c. write_status_state updates timestamp on actual transition
 write_status_state "idle"
 TRANSITION_CHANGE=$(read_last_state_change)
-assert_true "State transition updates timestamp" [ "$TRANSITION_CHANGE" -ge "$OLD_CHANGE" ]
+assert_true "State transition updates timestamp" [ "$TRANSITION_CHANGE" -gt 1700000001 ]
 
 # 4. clear_status_files removes last-state-change file
 write_last_state_change "1700000000"

--- a/tests/test-throttle.sh
+++ b/tests/test-throttle.sh
@@ -26,12 +26,13 @@ assert_true "First call passes throttle" \
 assert_false "Immediate repeat is throttled" \
     throttle_check "test-event-alpha" 120
 
-# 3. After cooldown expires, call should pass again (use 1-second cooldown)
+# 3. After cooldown expires, call should pass again (manipulate timestamp directly)
 rm -f "$THROTTLE_DIR/last-test-event-expire"
-throttle_check "test-event-expire" 1
-sleep 1.1
+throttle_check "test-event-expire" 60
+# Backdate the lock file to 61 seconds ago (no sleep needed)
+printf '%s\n' "$(( $(date +%s) - 61 ))" > "$THROTTLE_DIR/last-test-event-expire"
 assert_true "Call passes after cooldown expires" \
-    throttle_check "test-event-expire" 1
+    throttle_check "test-event-expire" 60
 
 # 4. Different event types should have independent throttles
 rm -f "$THROTTLE_DIR/last-test-idle-projectA" "$THROTTLE_DIR/last-test-perm-projectA"


### PR DESCRIPTION
## Summary

Addresses 3 easy audit issues — 2 docs + 1 test reliability.

- **Security considerations section in README** (#111, #114) — documents SHOW_TOOL_INFO secret exposure risk and webhook URL process listing visibility, with mitigations
- **Warning comment in script** (#111) — added near the SHOW_TOOL_INFO feature extraction code
- **Eliminate flaky sleep-based test timing** (#121) — replaced `sleep 1.1` in test-throttle.sh and `sleep 1` in test-heartbeat.sh with direct timestamp manipulation (no wall-clock dependency)

## Test plan
- [x] `shellcheck claude-notify.sh lib/*.sh install.sh` — clean
- [x] `bash tests/run-tests.sh` — 312/312 pass
- [ ] CI green on both ubuntu + macOS

Closes #111, closes #114, closes #121