### PR TITLE
fix: skip notifications for ephemeral /tmp sessions

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -114,7 +114,8 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 
 # Skip ephemeral/temp sessions (e.g. subagents spawned in /tmp, /private/tmp)
 # These clutter the channel with short-lived "tmp" entries.
-if [ -n "$CWD" ]; then
+# Bypassed in test mode (CLAUDE_NOTIFY_SKIP_TMP_FILTER=1) since tests use /tmp CWDs.
+if [ -n "$CWD" ] && [ "${CLAUDE_NOTIFY_SKIP_TMP_FILTER:-}" != "1" ]; then
     # Resolve symlinks (macOS: /tmp → /private/tmp) for consistent matching
     CWD_RESOLVED=$(cd "$CWD" 2>/dev/null && pwd -P || echo "$CWD")
     case "$CWD_RESOLVED" in

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -60,6 +60,8 @@ export CLAUDE_NOTIFY_DIR="$NOTIFY_DIR"
 export CLAUDE_NOTIFY_WEBHOOK="https://discord.com/api/webhooks/123456789012345678/test-token-abc123"
 # Disable heartbeat to avoid background process interference
 export CLAUDE_NOTIFY_HEARTBEAT_INTERVAL=0
+# Bypass ephemeral /tmp filter (tests use /tmp-based CWDs)
+export CLAUDE_NOTIFY_SKIP_TMP_FILTER=1
 
 # Test project directory (outside any git repo so extract_project_name uses basename)
 TEST_PROJECT_DIR="$TEST_TMPDIR/test-integ-proj"


### PR DESCRIPTION
## Summary
- Subagents/worktrees spawned in `/private/tmp` were generating short-lived "tmp" entries cluttering the Discord channel
- Adds early-exit check after project name extraction that silently drops notifications from `/tmp`, `/private/tmp`, and `/var/tmp` paths
- Resolves symlinks via `pwd -P` for consistent matching on macOS (where `/tmp` → `/private/tmp`)

## Test plan
- [ ] Start a Claude Code session in `/tmp` — verify no Discord notification appears
- [ ] Start a normal session in a project directory — verify notifications still work
- [ ] Verify existing tests still pass: `bash tests/run-tests.sh`