### PR TITLE
fix: skip notifications for worktree subagent sessions

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -112,14 +112,17 @@ TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // empty' 2>/dev/null)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 
-# Skip ephemeral/temp sessions (e.g. subagents spawned in /tmp, /private/tmp)
-# These clutter the channel with short-lived "tmp" entries.
+# Skip ephemeral sessions: temp dirs and Claude Code worktree subagents.
+# These clutter the channel with short-lived entries.
 # Bypassed in test mode (CLAUDE_NOTIFY_SKIP_TMP_FILTER=1) since tests use /tmp CWDs.
 if [ -n "$CWD" ] && [ "${CLAUDE_NOTIFY_SKIP_TMP_FILTER:-}" != "1" ]; then
     # Resolve symlinks (macOS: /tmp → /private/tmp) for consistent matching
     CWD_RESOLVED=$(cd "$CWD" 2>/dev/null && pwd -P || echo "$CWD")
     case "$CWD_RESOLVED" in
         /tmp|/tmp/*|/private/tmp|/private/tmp/*|/var/tmp|/var/tmp/*|/private/var/tmp|/private/var/tmp/*)
+            exit 0
+            ;;
+        */.claude/worktrees/agent-*)
             exit 0
             ;;
     esac


### PR DESCRIPTION
## Summary
- Claude Code spawns subagents in `.claude/worktrees/agent-*` paths, including nested worktrees (e.g., `.claude/worktrees/agent-ab88d935/.claude/worktrees/agent-a8d1692f`)
- These generate short-lived entries like `agent-a8d1692f` that clutter the Discord channel
- Extends the ephemeral session filter to also match `*/.claude/worktrees/agent-*` paths

## Test plan
- [ ] Verify existing tests pass: `bash tests/run-tests.sh` (403/403 passing locally)
- [ ] Start a session that spawns worktree subagents — verify subagent entries don't appear in Discord
- [ ] Verify parent session notifications still work normally