### PR TITLE
fix(heartbeat): export missing env vars and prevent zombie accumulation

### DIFF
--- a/claude-notify.sh
+++ b/claude-notify.sh
@@ -374,7 +374,8 @@ if [ "$HOOK_EVENT" = "SessionStart" ]; then
     export CLAUDE_NOTIFY_APPROVAL_COLOR CLAUDE_NOTIFY_PERMISSION_COLOR
     # Extra fields context for heartbeat (build_extra_fields reads these via env)
     export SESSION_ID CWD PERMISSION_MODE
-    export CLAUDE_NOTIFY_SHOW_SESSION_INFO CLAUDE_NOTIFY_SHOW_FULL_PATH
+    export CLAUDE_NOTIFY_SHOW_SESSION_INFO CLAUDE_NOTIFY_SHOW_FULL_PATH CLAUDE_NOTIFY_SHOW_TOOL_INFO
+    export CLAUDE_NOTIFY_SHOW_ACTIVITY CLAUDE_NOTIFY_ACTIVITY_THROTTLE
     nohup bash "$SCRIPT_DIR/lib/heartbeat.sh" "$PROJECT_NAME" </dev/null >/dev/null 2>&1 &
     safe_write_file "$HEARTBEAT_PID_FILE" "$!"
 

--- a/lib/heartbeat.sh
+++ b/lib/heartbeat.sh
@@ -32,7 +32,14 @@ cleanup() {
         rm -f "$PID_FILE" 2>/dev/null || true
     fi
 }
-trap cleanup EXIT TERM INT
+# TERM/INT must explicitly exit — trapping overrides the default terminate behavior,
+# so without exit the handler runs but the loop continues.
+terminate() {
+    cleanup
+    exit 0
+}
+trap cleanup EXIT
+trap terminate TERM INT
 
 # Write our PID (may already be written by caller, but ensure accuracy)
 safe_write_file "$PID_FILE" "$$"

--- a/lib/heartbeat.sh
+++ b/lib/heartbeat.sh
@@ -26,9 +26,11 @@ source "$SCRIPT_DIR/lib/notify-helpers.sh"
 # PID file for cleanup
 PID_FILE="$THROTTLE_DIR/heartbeat-pid-${PROJECT_NAME}"
 
-# Clean up PID file on exit
+# Clean up PID file on exit (only if it still contains our PID — avoids racing with newer heartbeats)
 cleanup() {
-    rm -f "$PID_FILE" 2>/dev/null || true
+    if [ -f "$PID_FILE" ] && [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ]; then
+        rm -f "$PID_FILE" 2>/dev/null || true
+    fi
 }
 trap cleanup EXIT TERM INT
 
@@ -56,13 +58,16 @@ while true; do
     fi
 
     # Check if a new session has superseded us (same project, different session ID)
-    # Exit if: we have a session ID but the stored one is gone (cleared) or different
     STORED_SID=$(read_session_id)
     MY_SID="${SESSION_ID:-}"
     if [ -n "$MY_SID" ]; then
+        # Exit if stored ID is gone (cleared) or different from ours
         if [ -z "$STORED_SID" ] || [ "$STORED_SID" != "$MY_SID" ]; then
             exit 0
         fi
+    elif [ -n "$STORED_SID" ]; then
+        # We have no session ID (legacy heartbeat) but a new session wrote one — exit
+        exit 0
     fi
 
     # Check if message ID exists (nothing to PATCH without it)


### PR DESCRIPTION
## Summary

- **Missing exports**: `CLAUDE_NOTIFY_SHOW_TOOL_INFO`, `CLAUDE_NOTIFY_SHOW_ACTIVITY`, and `CLAUDE_NOTIFY_ACTIVITY_THROTTLE` were loaded from `.env` but never exported to the heartbeat subprocess — heartbeat PATCHes never included tool count fields, causing embeds to show "Session started" with no metrics even after extended sessions
- **PID file cleanup race**: heartbeat cleanup trap unconditionally deleted the PID file on exit, even when a newer heartbeat had overwritten it with its own PID — made current heartbeat unkillable on next SessionStart, causing zombie accumulation (found 18 zombie heartbeat processes)
- **Legacy ownership gap**: heartbeats spawned without `SESSION_ID` skipped the session ownership check entirely and ran forever — now exits if a stored session ID exists but ours is empty

## Test plan

- [x] All 421 tests pass
- [ ] Start a new session and verify tool counts appear in Discord embed after heartbeat interval
- [ ] Start multiple sessions for the same project and verify only one heartbeat remains