### PR TITLE
chore: enforce zero-attribution (includeCoAuthoredBy: false)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}


### PR DESCRIPTION
Ensures `"includeCoAuthoredBy": false` in this repo's `.claude/settings.json` so no commit gets an AI Co-Authored-By trailer — project-level enforcement of the global zero-attribution policy. Settings-only.